### PR TITLE
graph: fix topo sort option

### DIFF
--- a/src/graph.test.ts
+++ b/src/graph.test.ts
@@ -338,3 +338,28 @@ test("should return reachable properties for a set of root", () => {
   ts = graph.strictlyReachableProperty(new Set(["a", "b"]), property);
   expect(ts).toEqual(new Set(["a"]));
 });
+
+test("Cells bug", () => {
+  const graph = new Graph<string>();
+  graph.addNode("a");
+  graph.addNode("b");
+  graph.addNode("m");
+  graph.addNode("p");
+  graph.addNode("mp");
+
+  graph.addEdge("a", "m");
+  graph.addEdge("b", "m");
+  graph.addEdge("m", "p");
+  graph.addEdge("p", "mp");
+  /*
+   a --
+       \
+         m --- p --- mp
+       /      
+   b --
+  */
+  const ts = graph.partialTopologicalSortRootsSet(["m", "p", "mp"], {
+    includeRoots: false,
+  });
+  expect(ts).toEqual(["mp", "p"]);
+});

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -233,9 +233,7 @@ export class Graph<T extends NodeId> {
         : option.next;
     const starts = includeRoots
       ? roots
-      : roots
-          .flatMap((root) => nextNodes(root))
-          .filter((id) => !roots.includes(id));
+      : roots.flatMap((root) => nextNodes(root));
     let stack: T[] = [];
     let visited = new Map<T, boolean>();
     let recursionStack = new Map<T, boolean>();


### PR DESCRIPTION
This MR changes the behavior of the  function `partialTopologicalSortRootsSet` when the option ` includeRoots:false `  is passed.
The behavior was not the one that was documented.